### PR TITLE
Update package.json to support node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "yarn run jest"
   },
   "engines": {
-    "node": ">8.*",
+    "node": ">=8.*",
     "yarn": "1.*"
   },
   "jest": {


### PR DESCRIPTION
This package is working well with Node 8, why expecting a version superior to 8 instead of including the actually LTS version with is 8 and work well with this package?