### PR TITLE
fix timeout return type error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export function debounce<F extends Procedure>(
     isImmediate: false
   },
 ): F {
-  let timeoutId: NodeJS.Timeout | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   return function(this: any, ...args: any[]) {
     const context = this;


### PR DESCRIPTION
Webpack was complaining about return type on line 35:
TS2322: Type 'number' is not assignable to type 'Timeout | undefined'.

Solution:
https://stackoverflow.com/questions/51040703/what-return-type-should-be-used-for-settimeout-in-typescript/51040768