### PR TITLE
Fix return type signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,10 @@ export function debounce<F extends Procedure>(
   options: Options = {
     isImmediate: false
   },
-): F {
+): (this: ThisParameterType<F>, ...args: Parameters<F>) => void {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-  return function(this: any, ...args: any[]) {
+  return function(this: ThisParameterType<F>, ...args: Parameters<F>) {
     const context = this;
 
     const doLater = function() {
@@ -37,5 +37,5 @@ export function debounce<F extends Procedure>(
     if (shouldCallNow) {
       func.apply(context, args);
     }
-  } as any
+  }
 }


### PR DESCRIPTION
Currently the type on the returned function is the same as what's passed in but that's not quite right because the debounced function doesn't return. This change reflects that and replaces the return with `void`, which also enables removing the `any` casting.